### PR TITLE
chore: clarify reset_paper.py output — rename 'Current state' label to 'State before reset'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ---
 
+## Session: 2026-04-11 (Part N) — Clarify reset_paper.py output label (#175)
+
+### Chore
+- **[#175] rename `Current state:` → `State before reset:` in `scripts/reset_paper.py`**: The pre-reset row-count snapshot was labelled `Current state:`, causing confusion — readers thought non-zero counts were post-reset residuals. Rename makes it clear the block shows what *will* be wiped, not what remains.
+
+---
+
 ## Session: 2026-04-11 (Part K) — Commit skill: branch + PR workflow (#168)
 
 ### Chore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,7 @@ Development history is documented in `docs/sessions/`. Each file covers one sess
 | session_2026_04_11k | Chore: commit skill updated — always create feature/defect branch, push branch, raise PR to main (#168) |
 | session_2026_04_11l | Fix: DB-persisted start-of-day balance prevents false daily loss notification (#170); reset_paper.py running-agent guard (#171) |
 | session_2026_04_11m | Chore: switch LLM to Groq qwen3-32b / llama-3.3-70b fallback (#173); commit backtest_status.sh chart flags (retro #101) |
+| session_2026_04_11n | Chore: clarify reset_paper.py output — rename 'Current state' label to 'State before reset' (#175) |
 
 ---
 

--- a/docs/sessions/session_2026_04_11n.md
+++ b/docs/sessions/session_2026_04_11n.md
@@ -1,0 +1,15 @@
+# Session Notes — 2026-04-11 (Part N)
+
+## Changes
+
+### 1. Chore: Clarify reset_paper.py output label (#175)
+
+**Bug report / Feature request:** The `reset_paper.py` script printed `Current state:` before showing row counts from the databases. Users read this as the post-reset verification output and were confused when non-zero counts appeared — believing rows had not been cleared.
+
+**Root cause / Motivation:** The label was ambiguous. The block in question shows a **pre-reset snapshot** of row counts to confirm what will be wiped, not the post-reset verification. The post-reset assertions run later and would raise errors if any rows remained.
+
+**Fix / Implementation:**
+- `scripts/reset_paper.py` — renamed `print("Current state:")` to `print("State before reset:")` in `main()`.
+- One-line cosmetic change; no logic altered.
+
+---

--- a/scripts/reset_paper.py
+++ b/scripts/reset_paper.py
@@ -183,7 +183,7 @@ def main() -> None:
         sys.exit(1)
 
     state = _current_state(paper_db, audit_db)
-    print("Current state:")
+    print("State before reset:")
     if "paper_error" in state:
         print(f"  paper_trading.db  ERROR: {state['paper_error']}")
     else:


### PR DESCRIPTION
Closes #175