### PR TITLE
chore: update trading-rules and add-pair skills for drawdown recovery + profit factor

### DIFF
--- a/.claude/skills/add-pair/SKILL.md
+++ b/.claude/skills/add-pair/SKILL.md
@@ -288,6 +288,8 @@ exec(open('tests/test_per_pair_params.py').read())
 - [ ] `src/cli/nl_parser.py`: PAIRS list (both full and short) updated; _SYSTEM_PROMPT updated
 - [ ] `docs/business_requirements.md`: scope count, FR-01 list, pair table row, version history
 - [ ] `docs/epics_stories_ac.md`: pair count references updated
+
+> **Note — Drawdown Recovery (#182):** When daily P&L ≤ -3%, `validate_buy()` Guard 1.2 only permits BTC/USD, ETH/USD, and BNB/USD. New pairs are **not** eligible during recovery unless explicitly added to `risk.drawdown_recovery.allowed_pairs` in `config.yaml`. By default, leave new pairs out of that list — it is intentionally restricted to proven major-cap pairs with low drawdown in bearish conditions.
 - [ ] `CLAUDE.md`: pairs table updated
 - [ ] `trailing_stop.per_pair_overrides` updated — or confirmed global default (5%/3%) is appropriate
 - [ ] `risk.correlation_clusters` reviewed — pair added to existing cluster, new cluster created, or left unclustered with rationale

--- a/.claude/skills/trading-rules/SKILL.md
+++ b/.claude/skills/trading-rules/SKILL.md
@@ -17,12 +17,14 @@ RULES (non-negotiable — enforced by the risk manager):
 - Never open more than the configured max_open_positions (currently 5) at the same time across all pairs
 - Always keep at least 5% of portfolio as cash reserve
 - If daily losses exceed 10% of starting balance, do NOT trade
+- **Drawdown Recovery Mode (#182)**: If daily P&L ≤ -3%, the agent enters drawdown recovery — `validate_buy()` Guard 1.2 rejects ALL pairs except BTC/USD, ETH/USD, BNB/USD, and caps position size at `available_cash × 10%` (half of normal). Recovery mode exits only when daily P&L recovers above -1.5% (hysteresis band). This is code-enforced — non-major pairs will be rejected even if the LLM proposes them. Config: `risk.drawdown_recovery`.
 - If 3 consecutive stop-losses occurred within the last 4 hours, do NOT propose_buy — circuit breaker is active. Resume only after the 4-hour window expires.
 - Volume Guard: Time-of-day restriction is currently disabled (`allowed_trading_hours.enabled: false`). Trades are still strictly blocked if volume drops below its per-pair rolling p15 volume floor.
 - Minimum Profit Floor Guardrail: The agent cannot close a position if the projected PNL is below the configured min_profit_floor_pct (e.g. 1.0%)
 - Fat Finger & Balance Guard: The agent cannot propose a trade exceeding 98% of the available cash, nor one below the Kraken minimum order size restrictions, nor if the asset experiences an anomalous flash crash.
 - Per-pair Max Buy Size: In bearish regime, each pair shows a "Max buy size" in its signal block. You MUST NOT propose_buy with usd_amount exceeding that value. Proven winners (ETH/BNB/DOGE) retain full size (caution=1.0 — buy the dip); underperformers (INJ/SUI/JUP/TIA) are cut to 35%; extreme meme coins (PEPE/BONK) are cut to 20–25%; WIF/HYPE/ARB/OP/STX/PENDLE cut to 40–50% of normal size. All caution limits are shown in the per-pair signal block.
 - Per-pair Signal Threshold: Some pairs require a higher confluence score before a BUY fires. Strict pairs (WIF/OP/TIA/INJ/PENDLE require 7; PEPE/ONDO require 6–8; BONK requires 9 — maximum gate). Moderate pairs (SOL/UNI/ARB/ONDO require 6). Default is 5. This is automatically enforced by the signal engine — you will only see Signal=BUY for a pair if it has met its threshold.
+- **Profit Factor Auto-Escalation (#183)**: Every cycle, each pair's 30-day rolling profit factor (PF) is injected into the signal engine. PF < 1.0 raises `buy_min_score +1`; PF < 0.7 raises it `+2`. This is transparent — if a pair is underperforming, the BUY threshold is silently raised and the pair will only appear as BUY if it clears the higher bar. When modifying signal scoring or thresholds, account for this dynamic escalation on top of any static per-pair score. Config: `signals.profit_factor_escalation`.
 
 YOUR ROLE:
 - You receive a market summary and portfolio state every 30 minutes


### PR DESCRIPTION
Updates internal skill files to capture new code-enforced rules from #182 and #183.

Closes #196
Refs #182 #183