### PR TITLE
Fix: backtest loader bare-list JSON support for BONK/PENDLE/ONDO (#198)

### DIFF
--- a/docs/sessions/session_2026_04_11v.md
+++ b/docs/sessions/session_2026_04_11v.md
@@ -1,0 +1,31 @@
+# Session Notes — 2026-04-11 (Part V)
+
+## Changes
+
+### 1. Fix: backtest loader crashes on bare-list JSON candle files
+
+**Bug report:** `scripts/analyse_h4_gate.py --start-date 2025-01-10 --summary-only` threw:
+```
+AttributeError: 'list' object has no attribute 'get'
+  File "tests/backtest/loader.py", line 100
+    raw_candles = data.get("result", {}).get(inner_key)
+```
+
+**Root cause:** The three pairs added in session_2026_04_11s (#186) — BONK/USD, PENDLE/USD, ONDO/USD — have their history candle files stored as bare JSON lists `[[ts, o, h, l, c, vwap, vol, count], ...]`. All other pairs use the Kraken API wrapper format `{"error": [], "result": {"XBTUSD": [...]}}`. The loader assumed the wrapper dict format unconditionally.
+
+**Fix (`tests/backtest/loader.py`):** Added `isinstance(data, list)` branch before calling `.get()`:
+
+```python
+# Before:
+raw_candles = data.get("result", {}).get(inner_key)
+
+# After:
+if isinstance(data, list):
+    raw_candles = data
+else:
+    raw_candles = data.get("result", {}).get(inner_key)
+```
+
+**Closes:** #198
+
+---

--- a/tests/backtest/loader.py
+++ b/tests/backtest/loader.py
@@ -97,7 +97,10 @@ def load_pair_candles(pair: str, history_dir: str = "history") -> Optional[list]
         logger.error("Failed to load %s: %s", path, e)
         return None
 
-    raw_candles = data.get("result", {}).get(inner_key)
+    if isinstance(data, list):
+        raw_candles = data
+    else:
+        raw_candles = data.get("result", {}).get(inner_key)
     if not raw_candles:
         logger.error("No candle data at result[%r] in %s", inner_key, path)
         return None


### PR DESCRIPTION
Closes #198

## What
`tests/backtest/loader.py` crashed with `AttributeError: 'list' object has no attribute 'get'` when loading BONK/PENDLE/ONDO pairs, whose history files are bare JSON lists not Kraken API wrapper dicts.

## Fix
Added `isinstance(data, list)` check in `load_pair_candles()` before calling `.get()`.