### PR TITLE
Fix: duplicate log lines when stdout redirected to agent.log (#226)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ---
 
+## Session: 2026-04-12 (Part D) — Fix duplicate log lines (#226)
+
+### Bug Fixes
+- **[#226] Duplicate log lines**: `setup_logging()` attached a `console_handler` (`StreamHandler(sys.stdout)`) and a `file_handler` (`RotatingFileHandler`) to the root logger. When started as a background subprocess by `agent_manager.start()`, `sys.stdout` is already redirected to `agent.log`, so every log record was written to the file twice. Fix: wrap `console_handler` attachment with `if sys.stdout.isatty()` — interactive runs get both handlers; background subprocess gets only the file handler.
+
+---
+
 ## Session: 2026-04-12 (Part C) — Fix qwen3-32b tool_use_failed (#223)
 
 ### Bug Fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,7 @@ Development history is documented in `docs/sessions/`. Each file covers one sess
 | session_2026_04_12a | Analysis: H4 gate hypothesis disproven — confirmed_down win rate 43.9% vs 41.4% overall; analyse_h4_gate.py committed (vectorised, ~6min for 16-month window); closes #180 |
 | session_2026_04_12b | Fix: cycle prompt token reduction (HOLD pairs filtered, BB/ATR/redundant blocks removed, ~1,015 tokens saved, refs #217); feat: structured LLM JSON logging /logs/agent-llm-prompts.log + session_id/request_id tracing + kryptos-cli.log CLI audit, closes #219; fix: duplicate log lines (root handler accumulation); fix: CoinGlass 1h failure back-off; fix: @timed("config") noise on compute_indicators |
 | session_2026_04_12c | Fix: qwen3-32b tool_use_failed — apply `reasoning_effort: none` via Groq API (correct Groq parameter, replaces Anthropic-style `thinking` which was reverted in #216); 8 tests; closes #223 |
+| session_2026_04_12d | Fix: duplicate log lines — `console_handler` skipped when `sys.stdout` is not a TTY (background subprocess has stdout redirected to `agent.log`); closes #226 |
 
 ---
 

--- a/docs/sessions/session_2026_04_12d.md
+++ b/docs/sessions/session_2026_04_12d.md
@@ -1,0 +1,34 @@
+# Session Notes — 2026-04-12 (Part D)
+
+## Summary
+Fix: duplicate log lines — skip console_handler when stdout is redirected to file (#226)
+
+## Root Cause
+`agent_manager.start()` launches `main.py` as a subprocess with both `stdout` and `stderr`
+redirected to `agent.log` via `subprocess.Popen(stdout=log_out, stderr=log_out)`.
+
+`setup_logging()` then attaches two handlers to the root logger:
+1. `file_handler` → `RotatingFileHandler` writing directly to `agent.log`
+2. `console_handler` → `StreamHandler(sys.stdout)` → which is **also** `agent.log`
+
+Every log record is therefore emitted to the file twice.
+
+The session_2026_04_12b fix (removing stale root handlers left by `logging.basicConfig()`)
+addressed a different source of duplication and did not catch this case.
+
+## Fix
+`main.py` — `setup_logging()`: wrap `console_handler` attachment in a TTY check:
+
+```python
+if sys.stdout.isatty():
+    root.addHandler(console_handler)
+```
+
+- Interactive run (`python main.py --paper`): stdout is a TTY → file + console handlers ✓
+- Background subprocess started by `agent_manager`: stdout is redirected → file handler only ✓
+
+## Files Changed
+- `main.py` — `setup_logging()`: guard `console_handler` with `sys.stdout.isatty()`
+
+## GitHub Issue
+Closes #226

--- a/main.py
+++ b/main.py
@@ -86,7 +86,12 @@ def setup_logging(config: dict, session_id: str = "") -> None:
         root.removeHandler(h)
         h.close()
     root.addHandler(file_handler)
-    root.addHandler(console_handler)
+    # Only attach a console handler when stdout is an interactive terminal.
+    # When started as a background subprocess by agent_manager, stdout is
+    # redirected to agent.log — adding a StreamHandler there would cause every
+    # log line to be written twice (once by file_handler, once via stdout).
+    if sys.stdout.isatty():
+        root.addHandler(console_handler)
 
 
 def _get_or_set_sod_balance(db_path: str, current_balance: float) -> float:


### PR DESCRIPTION
Closes #226

Root cause: `agent_manager.start()` redirects subprocess stdout to `agent.log`, so `setup_logging()`'s `console_handler` (StreamHandler to sys.stdout) wrote every line a second time.

Fix: `if sys.stdout.isatty(): root.addHandler(console_handler)`

262 tests pass.