### PR TITLE
Fix: validate_buy() one-position-per-pair guard

### DIFF
--- a/docs/sessions/session_2026_04_12f.md
+++ b/docs/sessions/session_2026_04_12f.md
@@ -1,0 +1,29 @@
+# Session Notes — 2026-04-12 (Part f)
+
+## Changes
+
+### 1. Fix: validate_buy() missing per-pair duplicate position guard (#230)
+
+**Bug report:** Multiple positions for the same pair (e.g. 4 × ETH/USD) could be opened simultaneously because `validate_buy()` had no guard preventing a second BUY on an already-open pair.
+
+**Root cause:** `validate_buy()` in `src/risk/risk_manager.py` checks total `open_positions_count` and correlation cluster limits, but never checked whether the **proposed pair itself** was already open. The correlation cluster guard at step 2a explicitly excludes the same pair (`p != pair`), so it did not block duplicates either.
+
+The fast backtest `decide()` function filters `s["pair"] not in open_pairs` — but this was never mirrored in the live code path.
+
+**Fix — `src/risk/risk_manager.py`:**
+- Added guard `-1` (first check in `validate_buy()`) that calls `_get_open_pairs()` and rejects with `"Position already open for {pair}"` if the pair already has an open position.
+- The `open_pairs` result is reused by the existing cluster guard at step 2a (removed its duplicate `_get_open_pairs()` DB call — minor efficiency improvement).
+
+**Tests — `tests/test_risk_manager.py`:**
+- `TestDuplicatePairGuard::test_duplicate_pair_rejected` — BUY on pair already open → rejected with correct reason.
+- `TestDuplicatePairGuard::test_new_pair_not_blocked` — BUY on different pair when ETH is open → approved normally.
+
+## Files Changed
+- `src/risk/risk_manager.py` — guard -1 added; cluster guard deduplication
+- `tests/test_risk_manager.py` — 2 new tests
+
+## Test Results
+264 passed (full suite)
+
+## Issues
+- Closes #230

--- a/src/risk/risk_manager.py
+++ b/src/risk/risk_manager.py
@@ -381,6 +381,15 @@ class RiskManager:
                     0.0,
                 )
 
+        # -1. Duplicate position guard — one open position per pair at a time (#230)
+        open_pairs = self._get_open_pairs()
+        if pair in open_pairs:
+            return (
+                False,
+                f"Position already open for {pair}",
+                0.0,
+            )
+
         # 0. Circuit breaker — pause all buys after consecutive stop-losses
         tripped, resume_in = self.is_circuit_open()
         if tripped:
@@ -463,7 +472,6 @@ class RiskManager:
         cluster_penalty_factor = 1.0
         cluster = self._get_correlation_cluster(pair)
         if cluster and self._correlation_clusters:
-            open_pairs = self._get_open_pairs()
             cluster_open = [p for p in open_pairs if p in cluster["pairs"] and p != pair]
             if len(cluster_open) >= self._max_cluster_positions:
                 return (

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -468,5 +468,81 @@ class TestPaperBrokerOverdrawGuard(unittest.TestCase):
         self.assertGreater(balance["available_cash_usd"], 0.0)
 
 
+class TestDuplicatePairGuard(unittest.TestCase):
+    """#230 — validate_buy() must reject a BUY when the pair already has an open position."""
+
+    def _make_cfg(self):
+        return {
+            "trading": {
+                "stop_loss_pct": 5,
+                "take_profit_pct": 10,
+                "max_position_pct": 30,
+                "max_open_positions": 10,
+            },
+            "risk": {
+                "min_cash_reserve_pct": 5,
+                "min_order_usd": 20,
+            },
+        }
+
+    def _make_broker_with_open_eth(self, starting_cash: float = 800.0):
+        """Return a PaperBroker that already has one open ETH/USD position."""
+        import tempfile
+        import os
+        from src.storage.database import init_paper_db
+        from src.exchange.paper_broker import PaperBroker
+
+        tmp_fd, tmp = tempfile.mkstemp(prefix="paper_", suffix=".db")
+        os.close(tmp_fd)
+        init_paper_db(tmp, starting_cash)
+        broker = PaperBroker(paper_db=tmp, slippage_pct=0.0, maker_fee_pct=0.0, config={})
+        broker.place_order(
+            pair="ETH/USD",
+            side="buy",
+            usd_amount=100.0,
+            current_price=3000.0,
+            stop_loss_pct=5.0,
+            take_profit_pct=12.0,
+        )
+        return broker, tmp
+
+    def test_duplicate_pair_rejected(self):
+        """BUY on a pair that already has an open position is rejected (#230)."""
+        broker, db_path = self._make_broker_with_open_eth()
+        cfg = self._make_cfg()
+        risk = RiskManager(cfg, db_path=db_path)
+
+        approved, reason, amount = risk.validate_buy(
+            pair="ETH/USD",
+            proposed_usd=100.0,
+            portfolio_balance_usd=1000.0,
+            available_cash_usd=700.0,
+            open_positions_count=1,
+            daily_loss_usd=0.0,
+            starting_balance_usd=1000.0,
+        )
+        self.assertFalse(approved)
+        self.assertIn("Position already open for ETH/USD", reason)
+        self.assertEqual(amount, 0.0)
+
+    def test_new_pair_not_blocked(self):
+        """BUY on a different pair (BTC) not blocked by duplicate guard when ETH is already open (#230)."""
+        broker, db_path = self._make_broker_with_open_eth()
+        cfg = self._make_cfg()
+        risk = RiskManager(cfg, db_path=db_path)
+
+        approved, reason, amount = risk.validate_buy(
+            pair="BTC/USD",
+            proposed_usd=100.0,
+            portfolio_balance_usd=1000.0,
+            available_cash_usd=700.0,
+            open_positions_count=1,
+            daily_loss_usd=0.0,
+            starting_balance_usd=1000.0,
+        )
+        self.assertTrue(approved, f"Expected BTC/USD to be approved but got: {reason}")
+        self.assertGreater(amount, 0.0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Root Cause: validate_buy() had no check preventing a second position on the same pair. The cluster guard at step 2a uses p != pair, so it explicitly excluded the proposed pair. Fix: Added guard -1 as the first check -- calls _get_open_pairs() and rejects if pair already open. open_pairs is reused in cluster guard (removes duplicate DB call). 2 new tests: test_duplicate_pair_rejected, test_new_pair_not_blocked. 264 tests pass. Closes #230