### PR TITLE
Fix: null macro data causes LLM to over-hold (#259)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,20 @@
 
 ---
 
-## Session: 2026-04-17 (Part B) — Fix volume dead-zone guard uses partial candle (#262)
+## Session: 2026-04-17 (Part C) — Fix null macro data causes LLM over-hold (#259)
+
+### Bug Fixes
+- **[#259] Null macro data causes LLM to HOLD every BUY candidate**: `fetch_fear_greed()` and `fetch_btc_dominance()` returned `None` on API failure even when fresh data was in cache. `build_sentiment_context()` showed `"unavailable"` with no guidance. Combined with bearish regime, the LLM interpreted maximum uncertainty and held everything.
+  - `fetch_fear_greed()`: On exception, fall back to stale cache within `stale_ttl_hours: 4` (hours). Returns stale dict with `stale_age_hours` key. None returned only when cache is cold or exceeds TTL.
+  - `build_sentiment_context()`: Cold cache shows `"treat as neutral, not bearish"` message. Stale data shows `"[stale Xh ago]"` label. 
+  - `fetch_btc_dominance()`: Same stale carry-forward, TTL 24h.
+  - `build_cycle_prompt()` rule 6: `"If any macro block shows 'unavailable', rely on technical signal scores alone. Missing macro data is NOT a reason to hold."`
+  - `config.yaml`: `sentiment.stale_ttl_hours: 4`, `btc_dominance.stale_ttl_hours: 24`
+  - **Files:** `src/analysis/features.py`, `src/agent/prompts.py`, `config.yaml`, `tests/test_stale_macro.py` (11 new tests)
+
+---
+
+ Fix volume dead-zone guard uses partial candle (#262)
 
 ### Bug Fixes
 - **[#262] Volume dead-zone guard uses in-progress candle instead of last completed candle**: `compute_indicators()` extracted `volume` from `df["volume"].iloc[-1]` which is the current open 15-min candle — partially accumulated. `rolling_volume_p15` is computed from 400 completed candles, so the comparison was systematically false (e.g. ETH 3.29 actual vs 24.48 floor mid-candle), blocking nearly every pair every cycle. Fix: dynamically select `_vol_idx` using `candle_interval` from config + last candle's Unix timestamp — if `last_ts + interval_secs <= time.now()` use `iloc[-1]` (candle closed), else `iloc[-2]` (last completed). **Files:** `src/analysis/indicators.py`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,7 @@ Development history is documented in `docs/sessions/`. Each file covers one sess
 | session_2026_04_13b | Docs: comprehensive README rewrite (19 sections, 1,474 lines, 68K) — BUY/SELL complete reference, 4 Mermaid sequence diagrams, defence mechanisms; new SETUP.md (10-section install guide) + setup.sh (automated setup script); closes #240 |
 | session_2026_04_17a | Fix: display.py PF tuple crash (#252); CI simplified — remove copilot-review gate, tests run unconditionally (#181); README Telegram Setup + Market Sentiment walkthrough sections (#253); UI design docs committed: docs/ui-designer.md + docs/user-interface/ (#251) |
 | session_2026_04_17b | Fix: volume dead-zone guard uses partial in-progress candle instead of last completed candle — dynamic `_vol_idx` via candle_interval config + timestamp comparison; closes #262 |
+| session_2026_04_17c | Fix: null macro data causes LLM to over-hold — stale carry-forward for Fear & Greed (4h) + BTC dominance (24h); cold-cache prompt says "treat as neutral"; prompt rule 6 for null-macro; 11 tests; closes #259 |
 
 ---
 

--- a/config.yaml
+++ b/config.yaml
@@ -890,6 +890,7 @@ regime:
     url: "https://api.coingecko.com/api/v3/global"
     fetch_timeout_secs: 5
     cache_minutes: 120              # Re-fetch at most every 2 hours
+    stale_ttl_hours: 24             # On fetch failure, return cached value up to 24 hours stale (#259)
     trend_min_change_pp: 0.5        # Minimum pp change over lookback_days to classify as rising/falling
     trend_lookback_days: 3          # Compare today vs N-1 days ago stored in agent_state
 
@@ -902,6 +903,7 @@ sentiment:
   fear_greed_url: "https://api.alternative.me/fng/?limit=1"
   fetch_timeout_secs: 5         # HTTP timeout for sentiment fetch
   cache_minutes: 60             # Re-fetch at most once per hour
+  stale_ttl_hours: 4            # On fetch failure, return cached value up to this many hours stale (#259)
   extreme_fear_threshold: 25    # Index <= this = extreme fear (potential buy zone)
   extreme_greed_threshold: 75   # Index >= this = extreme greed (caution on buys)
 

--- a/docs/sessions/session_2026_04_17c.md
+++ b/docs/sessions/session_2026_04_17c.md
@@ -1,0 +1,41 @@
+# Session Notes — 2026-04-17 (Part C)
+
+## Changes
+
+### 1. Fix: null macro data causes LLM to over-hold — stale carry-forward + prompt guidance (#259)
+
+**Bug report:** Cycles 478–488 (Apr 13–14) all returned "HOLD: not selected this cycle" for every BUY candidate despite valid signal scores (e.g. BNB score=7, min=5). Macro context showed `fear_greed_value: null`, `btc_dominance_pct: null`, `btc_dominance_trend: unknown`. The LLM interpreted maximum uncertainty + bearish regime as a blanket HOLD.
+
+**Root cause (compound):**
+1. `fetch_fear_greed()` and `fetch_btc_dominance()` returned `None` on API failure even when fresh data was in cache — they only used the cache on success, never on failure.
+2. When `build_sentiment_context()` got `None`, it rendered `"Fear & Greed Index: unavailable"` with no guidance, and the LLM inferred bearish/negative sentiment from silence.
+3. `build_cycle_prompt()` gave no instruction about how to behave when macro data is absent.
+
+**Fix: `src/analysis/features.py`**
+
+`fetch_fear_greed()`: On exception, fall back to stale cached data if within `stale_ttl_hours` (default 4h). Returns the cached dict with a `stale_age_hours` key added. If cache is cold or exceeds TTL, still returns `None`.
+
+`build_sentiment_context()`: 
+- When data is `None`: shows `"Fear & Greed Index: Data temporarily unavailable — treat as neutral, not bearish."` (explicit cold-cache instruction)
+- When data is stale (has `stale_age_hours`): appends `" [stale Xh ago]"` to the index line so the LLM knows the value is approximate
+
+`fetch_btc_dominance()`: Same stale carry-forward pattern, TTL 24h (dominance changes slowly). On exception falls back to in-memory cache within 24h; adds `stale_age_hours` to returned dict.
+
+**Fix: `src/agent/prompts.py`**
+
+Added rule 6 to `build_cycle_prompt()` task instructions:
+> "6. If any macro block shows 'unavailable', rely on the technical signal scores and reasons alone. Missing macro data is NOT a reason to hold."
+
+**Fix: `config.yaml`**
+
+- `sentiment.stale_ttl_hours: 4` — carries Fear & Greed for up to 4 hours after API failure
+- `regime.btc_dominance.stale_ttl_hours: 24` — carries BTC dominance for up to 24 hours after API failure
+
+**Files changed:**
+- `src/analysis/features.py` — `fetch_fear_greed()`, `build_sentiment_context()`, `fetch_btc_dominance()`
+- `src/agent/prompts.py` — rule 6 in task instructions
+- `config.yaml` — `stale_ttl_hours` in `sentiment` and `btc_dominance`
+- `tests/test_stale_macro.py` — 11 new tests
+
+**Closes:** #259  
+**Tests:** 309 passed (298 existing + 11 new)

--- a/src/agent/prompts.py
+++ b/src/agent/prompts.py
@@ -128,6 +128,7 @@ def build_cycle_prompt(
         "3. Call propose_sell for SELL-signal open positions with confirmed momentum reversal.",
         "4. Reason briefly (1 sentence) before each tool call. Make zero calls if no pairs meet your bar.",
         "5. If a [CYCLE TOP WARNING] block is present, treat Tier 3 / Tier 4 BUYs as blocked.",
+        "6. If any macro block shows 'unavailable', rely on the technical signal scores and reasons alone. Missing macro data is NOT a reason to hold.",
     ]
 
     return "\n".join(lines)

--- a/src/analysis/features.py
+++ b/src/analysis/features.py
@@ -506,6 +506,14 @@ def fetch_fear_greed(config: dict) -> Optional[dict]:
         return data
     except Exception as e:
         logger.warning("Fear & Greed fetch failed: %s", e)
+        # Fall back to stale cache rather than returning None (#259)
+        stale_ttl_secs = snt_cfg.get("stale_ttl_hours", 4) * 3600
+        if _sentiment_cache["data"] and (now - _sentiment_cache["fetched_at"]) < stale_ttl_secs:
+            age_hours = (now - _sentiment_cache["fetched_at"]) / 3600
+            stale = dict(_sentiment_cache["data"])
+            stale["stale_age_hours"] = round(age_hours, 1)
+            logger.info("Fear & Greed using stale data (age=%.1fh)", age_hours)
+            return stale
         return None
 
 
@@ -630,6 +638,14 @@ def fetch_btc_dominance(config: dict, db_path: Optional[str] = None) -> Optional
         btc_dom_pct = float(global_data.get("market_cap_percentage", {}).get("btc", 0.0))
     except Exception as e:
         logger.warning("[BTC_DOM] Fetch failed: %s", e)
+        # Fall back to stale cache rather than returning None (#259)
+        stale_ttl_secs = dom_cfg.get("stale_ttl_hours", 24) * 3600
+        if _btc_dom_cache["data"] and (now - _btc_dom_cache["fetched_at"]) < stale_ttl_secs:
+            age_hours = (now - _btc_dom_cache["fetched_at"]) / 3600
+            stale = dict(_btc_dom_cache["data"])
+            stale["stale_age_hours"] = round(age_hours, 1)
+            logger.info("[BTC_DOM] Using stale data (age=%.1fh)", age_hours)
+            return stale
         return None
 
     # Persist today's reading to DB for trend calculation
@@ -843,12 +859,17 @@ def build_sentiment_context(config: dict) -> str:
 
     data = fetch_fear_greed(config)
     if not data:
-        return "--- MARKET SENTIMENT ---\nFear & Greed Index: unavailable"
+        return (
+            "--- MARKET SENTIMENT ---\n"
+            "Fear & Greed Index: Data temporarily unavailable — treat as neutral, not bearish."
+        )
 
     value         = data["value"]
     label         = data["label"]
     fear_thresh   = snt_cfg.get("extreme_fear_threshold", 25)
     greed_thresh  = snt_cfg.get("extreme_greed_threshold", 75)
+    stale_age     = data.get("stale_age_hours")
+    stale_suffix  = f" [stale {stale_age:.0f}h ago]" if stale_age is not None else ""
 
     if value <= fear_thresh:
         interpretation = "EXTREME FEAR — market is oversold; historically a buy zone. BUY signals are more reliable."
@@ -863,7 +884,7 @@ def build_sentiment_context(config: dict) -> str:
 
     return (
         f"--- MARKET SENTIMENT (Fear & Greed Index) ---\n"
-        f"  Index: {value}/100 ({label})\n"
+        f"  Index: {value}/100 ({label}){stale_suffix}\n"
         f"  Interpretation: {interpretation}"
     )
 

--- a/tests/test_stale_macro.py
+++ b/tests/test_stale_macro.py
@@ -1,0 +1,255 @@
+"""
+Tests for #259 — Stale macro data carry-forward for Fear & Greed and BTC dominance.
+
+Tests cover:
+  1. fetch_fear_greed() returns stale data on API failure when within TTL
+  2. fetch_fear_greed() returns None when cache is cold (no prior data)
+  3. fetch_fear_greed() returns None when stale data exceeds TTL
+  4. fetch_fear_greed() stale data includes stale_age_hours key
+  5. fetch_btc_dominance() returns stale data on API failure when within TTL
+  6. fetch_btc_dominance() returns None when cache is cold
+  7. fetch_btc_dominance() stale data includes stale_age_hours key
+  8. build_sentiment_context() shows 'treat as neutral' when data is None
+  9. build_sentiment_context() shows '[stale Xh ago]' label when data is stale
+  10. build_cycle_prompt() task instructions include null-macro guidance (rule 6)
+"""
+import sys, os, time, types, unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# ── stub heavy deps ──────────────────────────────────────────────────────────
+timing_mod = types.ModuleType("src.utils.timing")
+timing_mod.timed = lambda *a, **kw: (lambda f: f)
+timing_mod.set_cycle_id = lambda *a: None
+timing_mod.set_request_id = lambda *a: None
+timing_mod.current_cycle_id = type("_CV", (), {"get": staticmethod(lambda: 0)})()
+sys.modules["src.utils.timing"] = timing_mod
+
+tz_mod = types.ModuleType("src.utils.tz")
+from datetime import datetime, timezone as _tz
+tz_mod.SGT = _tz.utc
+tz_mod.now_sgt = lambda: datetime.now(_tz.utc)
+tz_mod.now_sgt_iso = lambda: datetime.now(_tz.utc).isoformat()
+sys.modules["src.utils.tz"] = tz_mod
+# ─────────────────────────────────────────────────────────────────────────────
+
+import src.analysis.features as features
+from src.analysis.features import (
+    fetch_fear_greed,
+    fetch_btc_dominance,
+    build_sentiment_context,
+    _sentiment_cache,
+    _btc_dom_cache,
+)
+from src.agent.prompts import build_cycle_prompt
+
+# ─── shared config ────────────────────────────────────────────────────────────
+
+_SENTIMENT_CONFIG = {
+    "sentiment": {
+        "enabled": True,
+        "fear_greed_url": "https://api.alternative.me/fng/?limit=1",
+        "fetch_timeout_secs": 5,
+        "cache_minutes": 60,
+        "stale_ttl_hours": 4,
+        "extreme_fear_threshold": 25,
+        "extreme_greed_threshold": 75,
+    }
+}
+
+_DOM_CONFIG = {
+    "regime": {
+        "enabled": True,
+        "bearish_pairs_threshold": 6,
+        "bullish_pairs_threshold": 6,
+        "volatile_atr_multiplier": 1.5,
+        "ranging_macd_threshold": 0.001,
+        "bearish_caution_factor": 0.5,
+        "volatile_caution_factor": 0.7,
+        "btc_dominance": {
+            "enabled": True,
+            "url": "https://api.coingecko.com/api/v3/global",
+            "fetch_timeout_secs": 5,
+            "cache_minutes": 120,
+            "stale_ttl_hours": 24,
+            "trend_min_change_pp": 0.5,
+            "trend_lookback_days": 3,
+        },
+    }
+}
+
+
+def _reset_sentiment_cache():
+    _sentiment_cache["data"] = None
+    _sentiment_cache["fetched_at"] = 0
+
+
+def _reset_dom_cache():
+    _btc_dom_cache["data"] = None
+    _btc_dom_cache["fetched_at"] = 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestFearGreedStaleCarryForward(unittest.TestCase):
+
+    def setUp(self):
+        _reset_sentiment_cache()
+
+    def test_returns_stale_data_on_api_failure_within_ttl(self):
+        """On fetch failure, cached data within TTL is returned instead of None."""
+        # Seed cache with fresh-enough data (2 hours old, TTL = 4h)
+        _sentiment_cache["data"] = {"value": 21, "label": "Extreme Fear", "timestamp": ""}
+        _sentiment_cache["fetched_at"] = time.time() - 7200  # 2 hours ago
+
+        with patch("requests.get", side_effect=Exception("timeout")):
+            result = fetch_fear_greed(_SENTIMENT_CONFIG)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["value"], 21)
+        self.assertIn("stale_age_hours", result)
+        self.assertAlmostEqual(result["stale_age_hours"], 2.0, delta=0.1)
+
+    def test_returns_none_when_cache_cold_and_fetch_fails(self):
+        """On fetch failure with empty cache, None is returned."""
+        with patch("requests.get", side_effect=Exception("timeout")):
+            result = fetch_fear_greed(_SENTIMENT_CONFIG)
+        self.assertIsNone(result)
+
+    def test_returns_none_when_stale_exceeds_ttl(self):
+        """Cached data older than stale_ttl_hours is not returned on failure."""
+        # Seed cache with 5-hour-old data (TTL = 4h)
+        _sentiment_cache["data"] = {"value": 50, "label": "Neutral", "timestamp": ""}
+        _sentiment_cache["fetched_at"] = time.time() - 5 * 3600
+
+        with patch("requests.get", side_effect=Exception("timeout")):
+            result = fetch_fear_greed(_SENTIMENT_CONFIG)
+
+        self.assertIsNone(result)
+
+    def test_fresh_fetch_does_not_include_stale_key(self):
+        """A successful fresh fetch does not add stale_age_hours."""
+        mock_resp = unittest.mock.MagicMock()
+        mock_resp.json.return_value = {
+            "data": [{"value": "42", "value_classification": "Fear", "timestamp": ""}]
+        }
+        mock_resp.raise_for_status = lambda: None
+
+        with patch("requests.get", return_value=mock_resp):
+            result = fetch_fear_greed(_SENTIMENT_CONFIG)
+
+        self.assertIsNotNone(result)
+        self.assertNotIn("stale_age_hours", result)
+
+
+class TestBtcDominanceStaleCarryForward(unittest.TestCase):
+
+    def setUp(self):
+        _reset_dom_cache()
+
+    def test_returns_stale_data_on_fetch_failure_within_ttl(self):
+        """On fetch failure, cached BTC dominance within 24h TTL is returned."""
+        _btc_dom_cache["data"] = {
+            "btc_dominance_pct": 52.5,
+            "btc_dominance_trend": "flat",
+            "trend_change_pp": 0.1,
+        }
+        _btc_dom_cache["fetched_at"] = time.time() - 6 * 3600  # 6 hours ago
+
+        with patch("requests.get", side_effect=Exception("timeout")):
+            result = fetch_btc_dominance(_DOM_CONFIG)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["btc_dominance_pct"], 52.5)
+        self.assertIn("stale_age_hours", result)
+        self.assertAlmostEqual(result["stale_age_hours"], 6.0, delta=0.1)
+
+    def test_returns_none_when_cache_cold_and_fetch_fails(self):
+        """On fetch failure with empty BTC dom cache, None is returned."""
+        with patch("requests.get", side_effect=Exception("timeout")):
+            result = fetch_btc_dominance(_DOM_CONFIG)
+        self.assertIsNone(result)
+
+    def test_returns_none_when_stale_exceeds_ttl(self):
+        """BTC dominance data older than 24h is not returned on failure."""
+        _btc_dom_cache["data"] = {
+            "btc_dominance_pct": 51.0,
+            "btc_dominance_trend": "rising",
+            "trend_change_pp": 0.8,
+        }
+        _btc_dom_cache["fetched_at"] = time.time() - 25 * 3600  # 25 hours ago
+
+        with patch("requests.get", side_effect=Exception("timeout")):
+            result = fetch_btc_dominance(_DOM_CONFIG)
+
+        self.assertIsNone(result)
+
+
+class TestBuildSentimentContext(unittest.TestCase):
+
+    def setUp(self):
+        _reset_sentiment_cache()
+
+    def test_shows_neutral_unavailable_message_when_data_is_none(self):
+        """When fetch fails and cache is cold, prompt shows 'treat as neutral' text."""
+        with patch("requests.get", side_effect=Exception("timeout")):
+            result = build_sentiment_context(_SENTIMENT_CONFIG)
+
+        self.assertIn("unavailable", result.lower())
+        self.assertIn("neutral", result.lower())
+        # Message must say "not bearish" — not imply bearish sentiment
+        self.assertIn("not bearish", result.lower())
+
+    def test_shows_stale_label_when_data_is_stale(self):
+        """Stale data includes '[stale Xh ago]' label in the context string."""
+        _sentiment_cache["data"] = {"value": 21, "label": "Extreme Fear", "timestamp": ""}
+        _sentiment_cache["fetched_at"] = time.time() - 2 * 3600  # 2 hours ago
+
+        with patch("requests.get", side_effect=Exception("timeout")):
+            result = build_sentiment_context(_SENTIMENT_CONFIG)
+
+        self.assertIn("stale", result.lower())
+        self.assertIn("21", result)
+        self.assertIn("Extreme Fear", result)
+
+    def test_no_stale_label_on_fresh_data(self):
+        """Fresh data has no stale label in the context string."""
+        mock_resp = unittest.mock.MagicMock()
+        mock_resp.json.return_value = {
+            "data": [{"value": "42", "value_classification": "Fear", "timestamp": ""}]
+        }
+        mock_resp.raise_for_status = lambda: None
+
+        with patch("requests.get", return_value=mock_resp):
+            result = build_sentiment_context(_SENTIMENT_CONFIG)
+
+        self.assertNotIn("stale", result.lower())
+        self.assertIn("42", result)
+
+
+class TestBuildCyclePromptNullMacroRule(unittest.TestCase):
+
+    def _minimal_portfolio(self):
+        return {
+            "total_usd": 1000.0,
+            "available_cash_usd": 800.0,
+            "open_positions_count": 0,
+            "daily_pnl_usd": 0.0,
+            "daily_pnl_pct": 0.0,
+            "open_positions": [],
+            "max_per_trade": 200.0,
+        }
+
+    def test_task_instructions_include_null_macro_guidance(self):
+        """Rule 6 in task instructions tells LLM not to hold due to unavailable macro data."""
+        prompt = build_cycle_prompt(
+            cycle_time="12:00", portfolio=self._minimal_portfolio(), signals=[]
+        )
+        self.assertIn("unavailable", prompt.lower())
+        self.assertIn("not a reason to hold", prompt.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #259

## Problem
Cycles 478–488 all returned HOLD for every BUY candidate despite valid scores (e.g. BNB score=7, min=5). Macro context showed `fear_greed_value: null`, `btc_dominance_pct: null`. The LLM interpreted null macro + bearish regime as maximum uncertainty → blanket HOLD.

## Root Cause
1. `fetch_fear_greed()` and `fetch_btc_dominance()` silently returned `None` on API failure even when fresh data was available in cache
2. `build_sentiment_context()` showed only `"unavailable"` — no guidance, LLM inferred negative
3. `build_cycle_prompt()` had no instruction for null-macro behaviour

## Changes
- **`fetch_fear_greed()`**: On exception, fall back to stale cache within `stale_ttl_hours` (default 4h). Stale dict includes `stale_age_hours` key. Returns `None` only when cache is cold or exceeds TTL.
- **`build_sentiment_context()`**: Cold cache → `"treat as neutral, not bearish"`. Stale data → `"[stale Xh ago]"` label appended to index value.
- **`fetch_btc_dominance()`**: Same stale carry-forward, TTL 24h (dominance changes slowly).
- **`build_cycle_prompt()`**: Rule 6 added: *"If any macro block shows 'unavailable', rely on technical signal scores alone. Missing macro data is NOT a reason to hold."*
- **`config.yaml`**: `sentiment.stale_ttl_hours: 4`, `regime.btc_dominance.stale_ttl_hours: 24`

## Tests
11 new tests in `tests/test_stale_macro.py`; 309 total all passing ✅