### PR TITLE
fix: add pnl_pct to Telegram trade close notification (#248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ---
 
+## Session: 2026-04-18 (Part B) — Fix missing pnl_pct in Telegram trade close notification (#248)
+
+### Bug Fixes
+- **[#248] Telegram close message missing P&L percentage**: `send_trade_executed()` closing branch now reads `pnl_pct` from the trade dict (already populated by `close_position()`) and formats it as `P&L: +$14.23 (+8.12%) | Reason: take_profit`. One-line change in `src/notifications/notifier.py`. 309 tests pass.
+
+---
+
 ## Session: 2026-04-17 (Part D) — Raise max_position_pct 20% → 30% (#265)
 
 ### Config

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,7 @@ Development history is documented in `docs/sessions/`. Each file covers one sess
 | session_2026_04_17b | Fix: volume dead-zone guard uses partial in-progress candle instead of last completed candle — dynamic `_vol_idx` via candle_interval config + timestamp comparison; closes #262 |
 | session_2026_04_17c | Fix: null macro data causes LLM to over-hold — stale carry-forward for Fear & Greed (4h) + BTC dominance (24h); cold-cache prompt says "treat as neutral"; prompt rule 6 for null-macro; 11 tests; closes #259 |
 | session_2026_04_17d | Chore: raise max_position_pct 20% → 30%; drawdown recovery override 10% → 15%; prompt label updated; closes #265 |
+| session_2026_04_18b | Fix: missing pnl_pct in Telegram trade close message — `send_trade_executed()` now shows `(+8.12%)` alongside USD P&L; closes #248 |
 
 ---
 

--- a/src/notifications/notifier.py
+++ b/src/notifications/notifier.py
@@ -91,11 +91,12 @@ class Notifier:
 
         if pnl_usd is not None:
             # Closing trade
+            pnl_pct = trade.get("pnl_pct", 0.0)
             emoji = "✅" if pnl_usd >= 0 else "🔴"
             msg = (
                 f"{self._prefix}{emoji} <b>{side} CLOSED</b>: {pair}\n"
                 f"Exit: ${price:.2f} | Vol: {volume:.6f}\n"
-                f"P&L: ${pnl_usd:+.2f} | Reason: {reason}"
+                f"P&L: ${pnl_usd:+.2f} ({pnl_pct:+.2f}%) | Reason: {reason}"
             )
         else:
             # Opening trade


### PR DESCRIPTION
Closes #248

## Problem
`send_trade_executed()` closing branch was missing `pnl_pct`. A +$14 gain looks very different at 0.5% vs 12%.

## Fix
Read `pnl_pct` from the trade dict (already populated by `close_position()`) and include in the message.

**Before:** `P&L: +$14.23 | Reason: take_profit`
**After:** `P&L: +$14.23 (+8.12%) | Reason: take_profit`

## Tests
309/309 pass